### PR TITLE
Rename OPTIONS to ALCHEMY_OPTIONS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_script:
   - make resetdb
 
 install:
-  - pip install pipenv
+  - pip install -U pipenv 'backports.shutil_get_terminal_size; python_version<"3"' 'backports.weakref; python_version<"3"'
   - pipenv install -d --system --skip-lock
 
 script:

--- a/Makefile
+++ b/Makefile
@@ -51,9 +51,8 @@ coverage: ## check code coverage quickly with the default Python
 	pipenv run py.test \
 		--cov-report html \
 		--cov-report term-missing \
-		--cov=django_sorcery tests \
-		--doctest-modules \
-		tests django_sorcery
+		--cov=django_sorcery \
+		tests
 
 $(FILES):  ## helper target to run coverage tests on a module
 	pipenv run py.test --cov-report term-missing --cov-fail-under 100 --cov=$(subst /,.,$(firstword $(subst ., ,$@))) $(subst $(PACKAGE),tests,$(dir $@))test_$(notdir $@)

--- a/django_sorcery/db/url.py
+++ b/django_sorcery/db/url.py
@@ -172,7 +172,7 @@ def make_url_from_settings(alias):
 
     ``QUERY`` - querystring arguments for sqlalchemy url
 
-    ``OPTIONS`` - Optional arguments to be used to initialize the :py:class:`..sqlalchemy.SQLAlchemy` instance
+    ``ALCHEMY_OPTIONS`` - Optional arguments to be used to initialize the :py:class:`..sqlalchemy.SQLAlchemy` instance
 
         * ``session_class`` - a custom session class to be used
         * ``registry_class`` - a custom registy class to be used for scoping
@@ -208,4 +208,4 @@ def make_url_from_settings(alias):
 
     url.query.update(data.get("QUERY", {}))
 
-    return url, data.get("OPTIONS", {})
+    return url, data.get("ALCHEMY_OPTIONS", {})

--- a/tests/db/test_url.py
+++ b/tests/db/test_url.py
@@ -20,7 +20,7 @@ from django_sorcery.db.url import (
     SQLALCHEMY_CONNECTIONS={
         "bad": {},
         "minimal": {"DIALECT": "sqlite"},
-        "from_env_preserve": {"DIALECT": "sqlite", "OPTIONS": {"foo": "bar"}},
+        "from_env_preserve": {"DIALECT": "sqlite", "ALCHEMY_OPTIONS": {"foo": "bar"}},
         "default": {
             "DIALECT": "postgresql",
             "DRIVER": "psycopg2",

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -71,7 +71,7 @@ class TestModelChoiceField(TestCase):
 
     def test_apply_limit(self):
 
-        field = fields.ModelChoiceField(Owner, db, limit_choices_to=[Owner.id == 1])
+        field = fields.ModelChoiceField(Owner, db, limit_choices_to=[Owner.first_name == "first_name 1"])
         fields.apply_limit_choices_to_form_field(field)
         self.assertEqual(field.queryset.count(), 1)
 


### PR DESCRIPTION
This prevents key collusion with django `OPTIONS`