### PR TITLE
Implement formfield support in fields

### DIFF
--- a/django_sorcery/db/meta.py
+++ b/django_sorcery/db/meta.py
@@ -44,7 +44,7 @@ class composite_info(six.with_metaclass(model_info_meta)):
 
         self.properties = OrderedDict()
         for attr, prop, col in zip(attrs, self.prop.props, self.prop.columns):
-            self.properties[attr] = column_info(prop, col)
+            self.properties[attr] = column_info(prop, col, self)
 
     @property
     def field_names(self):
@@ -59,17 +59,38 @@ class composite_info(six.with_metaclass(model_info_meta)):
     def related_model(self):
         return self.prop.composite_class
 
+    def __repr__(self):
+        return "<composite_info({!s}, {!s}.{!s})>".format(
+            self.related_model.__name__, self.prop.parent.class_.__name__, self.prop.key
+        )
+
 
 class column_info(object):
     """
     A helper class that makes sqlalchemy property and column inspection easier
     """
 
-    __slots__ = ("property", "column")
+    __slots__ = ("property", "column", "parent")
 
-    def __init__(self, prop, column):
+    def __init__(self, prop, column, parent=None):
         self.property = prop
         self.column = column
+        self.parent = parent
+
+    @property
+    def validators(self):
+        return self.column.info.get("validators") or []
+
+    @property
+    def required(self):
+        return self.column.info.get("required", not self.column.nullable)
+
+    def formfield(self, form_class=None, **kwargs):
+        form_class = form_class or self.column.info.get("form_class")
+        if form_class is not None:
+            field_kwargs = self.field_kwargs
+            field_kwargs.update(kwargs)
+            return form_class(**field_kwargs)
 
     @property
     def name(self):
@@ -81,27 +102,45 @@ class column_info(object):
 
     @property
     def field_kwargs(self):
-        kwargs = {"label": capfirst(" ".join(self.property.key.split("_"))), "help_text": self.property.doc}
+        kwargs = {}
+        if self.column.doc:
+            kwargs["help_text"] = self.column.doc
+
+        label = self.column.info.get("label")
+        if label:
+            kwargs["label"] = label
+        else:
+            label = self.property.key if self.property is not None else self.column.key
+            if label:
+                kwargs["label"] = capfirst(" ".join(label.split("_")))
+
+        with suppress(AttributeError):
+            if self.column.type.length is not None:
+                kwargs["max_length"] = self.column.type.length
 
         with suppress(AttributeError):
             enum_class = self.column.type.enum_class
             if enum_class is not None:
                 kwargs["enum_class"] = self.column.type.enum_class
             else:
-                kwargs["choices"] = self.column.type.enums
+                kwargs["choices"] = [(x, x) for x in self.column.type.enums]
+
+            kwargs.pop("max_length", None)
 
         with suppress(AttributeError):
             max_digits = self.column.type.precision
             decimal_places = self.column.type.scale
             if self.column.type.python_type == Decimal:
-                kwargs["max_digits"] = max_digits
-                kwargs["decimal_places"] = decimal_places
+                if max_digits is not None:
+                    kwargs["max_digits"] = max_digits
+                if decimal_places is not None:
+                    kwargs["decimal_places"] = decimal_places
 
-        with suppress(AttributeError):
-            kwargs["max_length"] = self.column.type.length
+        kwargs["required"] = self.required
+        kwargs["validators"] = self.validators
 
-        kwargs["required"] = self.column.info.get("required", not self.column.nullable)
-        kwargs["validators"] = self.column.info.get("validators", [])
+        if self.column.info.get("widget_class"):
+            kwargs["widget"] = self.column.info.get("widget_class")
 
         return kwargs
 
@@ -231,12 +270,12 @@ class model_info(six.with_metaclass(model_info_meta)):
         for col in self.mapper.primary_key:
             attr = self.mapper.get_property_by_column(col)
             if attr.key not in self.primary_keys:
-                self.primary_keys[attr.key] = column_info(attr, col)
+                self.primary_keys[attr.key] = column_info(attr, col, self)
 
         for col in self.mapper.columns:
             attr = self.mapper.get_property_by_column(col)
             if attr.key not in self.primary_keys and attr.key not in self.properties:
-                self.properties[attr.key] = column_info(attr, col)
+                self.properties[attr.key] = column_info(attr, col, self)
 
         for composite in self.mapper.composites:
             if composite.key not in self.composites:
@@ -245,6 +284,27 @@ class model_info(six.with_metaclass(model_info_meta)):
         for relationship in self.mapper.relationships:
             if relationship.key not in self.relationships:
                 self.relationships[relationship.key] = relation_info(relationship)
+
+    def __dir__(self):
+        return (
+            dir(super(model_info, self))
+            + list(vars(type(self)))
+            + list(self.primary_keys)
+            + list(self.properties)
+            + list(self.composites)
+            + list(self.relationships)
+        )
+
+    def __getattr__(self, name):
+        if name in self.primary_keys:
+            return self.primary_keys[name]
+        if name in self.properties:
+            return self.properties[name]
+        if name in self.composites:
+            return self.composites[name]
+        if name in self.relationships:
+            return self.relationships[name]
+        return getattr(super(model_info, self), name)
 
     @property
     def field_names(self):

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ ignore = E501,W503
 max-line-length = 120
 exclude=.eggs,.tox,.git,*/migrations/*,*/static/CACHE/*,docs,node_modules
 select = C,E,F,W,B,B950
-ignore = E501
+ignore = E501,W503
 
 [yapf]
 based_on_style = pep8

--- a/tests/db/test_fields.py
+++ b/tests/db/test_fields.py
@@ -4,9 +4,12 @@ import enum
 
 import sqlalchemy as sa
 
+from django import forms as djangoforms
 from django.core import validators as django_validators
+from django.forms import fields as djangofields
 
-from django_sorcery.db import fields
+from django_sorcery import fields as formfields
+from django_sorcery.db import fields, meta
 
 from ..base import TestCase
 
@@ -17,9 +20,19 @@ class DummyEnum(enum.Enum):
 
 
 class TestFields(TestCase):
+    def test_can_init_like_sqlalchemy(self):
+        col_type = sa.String()
+        column = fields.Field("test", col_type)
+
+        self.assertEqual(column.name, "test")
+        self.assertEqual(column.type, col_type)
+
     def test_boolean_field(self):
         column = fields.BooleanField()
         self.assertIsInstance(column.type, sa.Boolean)
+        self.assertFalse(column.nullable)
+        form_field = meta.column_info(None, column).formfield()
+        self.assertIsInstance(form_field, djangofields.BooleanField)
 
     def test_char_field(self):
         column = fields.CharField()
@@ -28,50 +41,87 @@ class TestFields(TestCase):
 
         column = fields.CharField(max_length=120)
         self.assertEqual(column.type.length, 120)
+        form_field = meta.column_info(None, column).formfield()
+        self.assertIsInstance(form_field, djangofields.CharField)
 
     def test_date_field(self):
         column = fields.DateField()
         self.assertIsInstance(column.type, sa.Date)
+        form_field = meta.column_info(None, column).formfield()
+        self.assertIsInstance(form_field, djangofields.DateField)
 
     def test_datetime_field(self):
         column = fields.DateTimeField()
         self.assertIsInstance(column.type, sa.DateTime)
+        form_field = meta.column_info(None, column).formfield()
+        self.assertIsInstance(form_field, djangofields.DateTimeField)
 
     def test_duration_field(self):
         column = fields.DurationField()
         self.assertIsInstance(column.type, sa.Interval)
+        form_field = meta.column_info(None, column).formfield()
+        self.assertIsInstance(form_field, djangofields.DurationField)
 
     def test_decimal_field(self):
         column = fields.DecimalField()
         self.assertIsInstance(column.type, sa.Numeric)
         self.assertTrue(column.type.asdecimal)
+        form_field = meta.column_info(None, column).formfield()
+        self.assertIsInstance(form_field, djangofields.DecimalField)
 
     def test_email_field(self):
         column = fields.EmailField()
         self.assertIsInstance(column.type, sa.String)
-        self.assertEqual(column.info, {"validators": [django_validators.validate_email], "required": False})
+        self.assertEqual(
+            column.info,
+            {
+                "form_class": djangofields.EmailField,
+                "required": False,
+                "validators": [django_validators.validate_email],
+            },
+        )
+        form_field = meta.column_info(None, column).formfield()
+        self.assertIsInstance(form_field, djangofields.EmailField)
 
-    def test_enum_field(self):
-        with self.assertRaises(KeyError):
-            column = fields.EnumField()
+    def test_enum_field_bad_config(self):
+        with self.assertRaises(TypeError):
+            fields.EnumField()
 
-        with self.assertRaises(KeyError):
-            column = fields.EnumField(DummyEnum)
+        with self.assertRaises(TypeError):
+            fields.EnumField(DummyEnum)
 
+    def test_enum_field_plain_choices(self):
+        column = fields.EnumField(choices=["a", "b"])
+        self.assertIsInstance(column.type, sa.Enum)
+        self.assertIsNone(column.type.enum_class)
+        self.assertEqual(column.type.enums, ["a", "b"])
+        form_field = meta.column_info(None, column).formfield()
+        self.assertIsInstance(form_field, djangofields.TypedChoiceField)
+        self.assertEqual(form_field.choices, [("a", "a"), ("b", "b")])
+
+    def test_enum_field_enum_choices(self):
         column = fields.EnumField(choices=DummyEnum)
         self.assertIsInstance(column.type, sa.Enum)
         self.assertEqual(column.type.enum_class, DummyEnum)
+        form_field = meta.column_info(None, column).formfield()
+        self.assertIsInstance(form_field, formfields.EnumField)
 
+    def test_enum_field_enum_choices_with_constraint_name(self):
         column = fields.EnumField(choices=DummyEnum, constraint_name="dummy")
         self.assertIsInstance(column.type, sa.Enum)
         self.assertEqual(column.type.enum_class, DummyEnum)
         self.assertEqual(column.type.name, "dummy")
+        form_field = meta.column_info(None, column).formfield()
+        self.assertIsInstance(form_field, formfields.EnumField)
 
+    def test_enum_field_enum_choices_with_constraint_name_and_no_native_type(self):
         column = fields.EnumField(choices=DummyEnum, constraint_name="dummy", native_enum=False)
         self.assertIsInstance(column.type, sa.Enum)
         self.assertEqual(column.type.enum_class, DummyEnum)
         self.assertEqual(column.type.name, "dummy")
         self.assertFalse(column.type.native_enum)
+        form_field = meta.column_info(None, column).formfield()
+        self.assertIsInstance(form_field, formfields.EnumField)
 
     def test_float_field(self):
         column = fields.FloatField()
@@ -85,44 +135,95 @@ class TestFields(TestCase):
         column = fields.FloatField(max_digits=10)
         self.assertEqual(column.type.precision, 10)
 
+        form_field = meta.column_info(None, column).formfield()
+        self.assertIsInstance(form_field, djangofields.FloatField)
+
     def test_integer_field(self):
         column = fields.IntegerField()
         self.assertIsInstance(column.type, sa.Integer)
+
+        form_field = meta.column_info(None, column).formfield()
+        self.assertIsInstance(form_field, djangofields.IntegerField)
 
     def test_biginteger_field(self):
         column = fields.BigIntegerField()
         self.assertIsInstance(column.type, sa.BigInteger)
 
+        form_field = meta.column_info(None, column).formfield()
+        self.assertIsInstance(form_field, djangofields.IntegerField)
+
     def test_smallinteger_field(self):
         column = fields.SmallIntegerField()
         self.assertIsInstance(column.type, sa.SmallInteger)
 
+        form_field = meta.column_info(None, column).formfield()
+        self.assertIsInstance(form_field, djangofields.IntegerField)
+
     def test_nullboolean_field(self):
         column = fields.NullBooleanField()
         self.assertIsInstance(column.type, sa.Boolean)
-        self.assertFalse(column.nullable)
+        self.assertTrue(column.nullable)
+
+        form_field = meta.column_info(None, column).formfield()
+        self.assertIsInstance(form_field, djangofields.NullBooleanField)
 
     def test_slug_field(self):
-        column = fields.SlugField()
+        column = fields.SlugField(label="test")
         self.assertIsInstance(column.type, sa.String)
-        self.assertEqual(column.info, {"validators": [django_validators.validate_slug], "required": False})
+        self.assertEqual(
+            column.info,
+            {
+                "form_class": djangofields.SlugField,
+                "label": "test",
+                "required": False,
+                "validators": [django_validators.validate_slug],
+            },
+        )
+
+        form_field = meta.column_info(None, column).formfield()
+        self.assertIsInstance(form_field, djangofields.SlugField)
 
     def test_text_field(self):
         column = fields.TextField()
         self.assertIsInstance(column.type, sa.Text)
 
+        form_field = meta.column_info(None, column).formfield()
+        self.assertIsInstance(form_field, djangofields.CharField)
+        self.assertIsInstance(form_field.widget, djangoforms.Textarea)
+
     def test_time_field(self):
         column = fields.TimeField()
         self.assertIsInstance(column.type, sa.Time)
 
+        form_field = meta.column_info(None, column).formfield()
+        self.assertIsInstance(form_field, djangofields.TimeField)
+
     def test_timestamp_field(self):
         column = fields.TimestampField()
         self.assertIsInstance(column.type, sa.TIMESTAMP)
+
+        form_field = meta.column_info(None, column).formfield()
+        self.assertIsInstance(form_field, djangofields.DateTimeField)
 
     def test_url_field(self):
         column = fields.URLField()
         self.assertIsInstance(column.type, sa.String)
         self.assertIsInstance(column.info["validators"][0], django_validators.URLValidator)
 
+        form_field = meta.column_info(None, column).formfield()
+        self.assertIsInstance(form_field, djangofields.URLField)
+
     def test_binary_field(self):
-        fields.TimeField()
+        fields.BinaryField()
+
+    def test_override_form_class(self):
+        column = fields.EnumField(choices=["a", "b"], form_class=djangofields.ChoiceField)
+
+        form_field = meta.column_info(None, column).formfield()
+        self.assertIs(type(form_field), djangofields.ChoiceField)
+        self.assertIsNot(type(form_field), djangofields.TypedChoiceField)
+
+        column = fields.URLField(form_class=djangofields.CharField)
+        form_field = meta.column_info(None, column).formfield()
+        self.assertIs(type(form_field), djangofields.CharField)
+        self.assertIsNot(type(form_field), djangofields.URLField)

--- a/tests/db/test_meta.py
+++ b/tests/db/test_meta.py
@@ -9,7 +9,7 @@ from django_sorcery.db import meta  # noqa
 
 from ..base import TestCase
 from ..models_terrible_relations import Foo
-from ..testapp.models import COLORS, AllKindsOfFields, Owner, Point, Vehicle, VehicleType, Vertex
+from ..testapp.models import COLORS, AllKindsOfFields, Business, Owner, Point, Vehicle, VehicleType, Vertex
 
 
 class TestModelMeta(TestCase):
@@ -29,6 +29,35 @@ class TestModelMeta(TestCase):
 
         self.assertEqual(set(info.field_names), {"id", "first_name", "last_name", "vehicles"})
 
+        self.assertEqual(
+            [attr for attr in dir(info) if not attr.startswith("__")],
+            [
+                "_configure",
+                "_field_names",
+                "composites",
+                "field_names",
+                "first_name",
+                "id",
+                "last_name",
+                "mapper",
+                "model_class",
+                "primary_keys",
+                "properties",
+                "relationships",
+                "vehicles",
+            ],
+        )
+        self.assertEqual(info.id, info.primary_keys["id"])
+        self.assertEqual(info.first_name, info.properties["first_name"])
+        self.assertEqual(info.vehicles, info.relationships["vehicles"])
+        with self.assertRaises(AttributeError):
+            info.abc
+
+        info = meta.model_info(Business)
+        self.assertEqual(info.location, info.composites["location"])
+        self.assertEqual(info.other_location, info.composites["other_location"])
+        self.assertNotEqual(info.location, info.other_location)
+
     def test_model_meta_with_mapper(self):
         mapper = Vehicle.owner.property.parent
         self.assertEqual(meta.model_info(mapper), meta.model_info(Vehicle))
@@ -41,8 +70,11 @@ class TestCompositeMeta(TestCase):
         self.assertEqual(set(info.composites.keys()), {"start", "end"})
 
         start = info.composites["start"]
+        end = info.composites["end"]
         self.assertEqual(set(start.properties.keys()), {"x", "y"})
         self.assertEqual(start.properties["x"].property, Vertex.x1.property)
+        self.assertEqual(repr(start), "<composite_info(Point, Vertex.start)>")
+        self.assertEqual(repr(end), "<composite_info(Point, Vertex.end)>")
 
         self.assertEqual(set(start.field_names), {"x", "y"})
         self.assertEqual(start.related_model, Point)
@@ -56,6 +88,8 @@ class TestRelationshipMeta(TestCase):
 
         self.assertEqual(rel.related_model, Owner)
         self.assertEqual(rel.related_table, Owner.__table__)
+        self.assertEqual(rel.parent_mapper, Vehicle.__mapper__)
+        self.assertEqual(rel.related_mapper, Owner.__mapper__)
         self.assertEqual(rel.name, "owner")
         self.assertEqual(rel.direction, sa.orm.relationships.MANYTOONE)
         self.assertEqual(rel.foreign_keys, [Vehicle._owner_id.property.columns[0]])
@@ -76,6 +110,8 @@ class TestRelationshipMeta(TestCase):
 
         self.assertEqual(rel.related_model, Vehicle)
         self.assertEqual(rel.related_table, Vehicle.__table__)
+        self.assertEqual(rel.parent_mapper, Owner.__mapper__)
+        self.assertEqual(rel.related_mapper, Vehicle.__mapper__)
         self.assertEqual(rel.name, "vehicles")
         self.assertEqual(rel.direction, sa.orm.relationships.ONETOMANY)
         self.assertEqual(rel.foreign_keys, [Vehicle._owner_id.property.columns[0]])
@@ -126,30 +162,26 @@ class TestColumnMeta(TestCase):
             },
             col.field_kwargs,
         )
+        self.assertIs(col.validators, col.column.info["validators"])
+        self.assertTrue(col.required)
 
         col = info.properties["type"]
         self.assertDictEqual(
-            {
-                "enum_class": VehicleType,
-                "help_text": None,
-                "label": "Type",
-                "max_length": 3,
-                "required": True,
-                "validators": [],
-            },
+            {"enum_class": VehicleType, "label": "Type", "required": True, "validators": []}, col.field_kwargs
+        )
+        self.assertTrue(col.required)
+
+        col = info.properties["msrp"]
+        validator = col.column.info["validators"][0]
+        self.assertIsInstance(validator, django_validators.DecimalValidator)
+        self.assertDictEqual(
+            {"decimal_places": 2, "label": "Msrp", "max_digits": 10, "required": False, "validators": [validator]},
             col.field_kwargs,
         )
 
         col = info.properties["paint"]
         self.assertDictEqual(
-            {
-                "choices": COLORS,
-                "help_text": None,
-                "label": "Paint",
-                "max_length": 6,
-                "required": False,
-                "validators": [],
-            },
+            {"choices": [(x, x) for x in COLORS], "label": "Paint", "required": False, "validators": []},
             col.field_kwargs,
         )
         self.assertEqual(col.parent_model, Vehicle)
@@ -157,14 +189,4 @@ class TestColumnMeta(TestCase):
 
         info = meta.model_info(AllKindsOfFields)
         col = info.properties["decimal"]
-        self.assertDictEqual(
-            {
-                "decimal_places": None,
-                "help_text": None,
-                "label": "Decimal",
-                "max_digits": None,
-                "required": False,
-                "validators": [],
-            },
-            col.field_kwargs,
-        )
+        self.assertDictEqual({"label": "Decimal", "required": False, "validators": []}, col.field_kwargs)

--- a/tests/db/test_models.py
+++ b/tests/db/test_models.py
@@ -38,19 +38,19 @@ class TestModels(TestCase):
     def test_simple_repr(self):
 
         vehicle = Vehicle()
-        self.assertEqual(models.simple_repr(vehicle), "Vehicle(id=None)")
+        self.assertEqual(models.simple_repr(vehicle), "Vehicle(id=None, is_used=False)")
 
         vehicle.name = "Test"
-        self.assertEqual(models.simple_repr(vehicle), "Vehicle(id=None, name='Test')")
+        self.assertEqual(models.simple_repr(vehicle), "Vehicle(id=None, is_used=False, name='Test')")
 
         vehicle.id = 1234
-        self.assertTrue(models.simple_repr(vehicle), "Vehicle(id=1234, name='Test')")
+        self.assertTrue(models.simple_repr(vehicle), "Vehicle(id=1234, is_used=False, name='Test')")
 
         vehicle.id = "abc"
-        self.assertTrue(models.simple_repr(vehicle), "Vehicle(id='abc', name='Test')")
+        self.assertTrue(models.simple_repr(vehicle), "Vehicle(id='abc', is_used=False, name='Test')")
 
         vehicle.id = b"abc"
-        self.assertTrue(models.simple_repr(vehicle), "Vehicle(id='abc', name='Test')")
+        self.assertTrue(models.simple_repr(vehicle), "Vehicle(id='abc', is_used=False, name='Test')")
 
     def test_primary_keys(self):
         pks = models.get_primary_keys(Vehicle, {"pk": 1234})
@@ -97,6 +97,7 @@ class TestModels(TestCase):
             {
                 "created_at": None,
                 "is_used": True,
+                "msrp": None,
                 "name": "vehicle",
                 "options": [3, 4],
                 "owner": 2,
@@ -123,6 +124,7 @@ class TestModels(TestCase):
             {
                 "created_at": None,
                 "is_used": True,
+                "msrp": None,
                 "name": "vehicle",
                 "options": [3, 4],
                 "paint": "red",
@@ -164,8 +166,9 @@ class TestModels(TestCase):
                 "_owner_id": None,
                 "created_at": None,
                 "id": None,
-                "is_used": None,
+                "is_used": False,
                 "name": None,
+                "msrp": None,
                 "paint": None,
                 "type": VehicleType.car,
             },
@@ -183,7 +186,7 @@ class TestModels(TestCase):
             {
                 "id": None,
                 "name": "test",
-                "employees": None,
+                "employees": 5,
                 "location": {"state": "state 1", "street": "street 1", "zip": "zip 1"},
                 "other_location": {"state": "state 2", "street": "street 2", "zip": "zip 2"},
             },
@@ -208,12 +211,13 @@ class TestModels(TestCase):
                 "created_at": None,
                 "id": None,
                 "is_used": True,
-                "paint": "red",
-                "type": VehicleType.car,
+                "msrp": None,
                 "name": "vehicle",
-                "owner": {"id": None, "first_name": "first_name", "last_name": "last_name"},
                 "options": [{"id": None, "name": "option 1"}, {"id": None, "name": "option 2"}],
+                "owner": {"id": None, "first_name": "first_name", "last_name": "last_name"},
+                "paint": "red",
                 "parts": [{"id": None, "name": "part 1"}, {"id": None, "name": "part 2"}],
+                "type": VehicleType.car,
             },
             models.serialize(vehicle, Vehicle.owner, Vehicle.options, Vehicle.parts),
         )
@@ -225,12 +229,12 @@ class TestModels(TestCase):
             "created_at": None,
             "id": 1,
             "is_used": True,
-            "paint": "red",
-            "type": VehicleType.car,
             "name": "vehicle",
-            "owner": {"id": 2, "first_name": "first_name", "last_name": "last_name"},
             "options": [{"id": 3, "name": "option 1"}, {"id": 4, "name": "option 2"}],
+            "owner": {"id": 2, "first_name": "first_name", "last_name": "last_name"},
+            "paint": "red",
             "parts": [{"id": 5, "name": "part 1"}, {"id": 6, "name": "part 2"}],
+            "type": VehicleType.car,
         }
 
         vehicle = models.deserialize(Vehicle, data)
@@ -241,12 +245,13 @@ class TestModels(TestCase):
                 "created_at": None,
                 "id": 1,
                 "is_used": True,
-                "paint": "red",
-                "type": VehicleType.car,
+                "msrp": None,
                 "name": "vehicle",
-                "owner": {"id": 2, "first_name": "first_name", "last_name": "last_name"},
                 "options": [{"id": 3, "name": "option 1"}, {"id": 4, "name": "option 2"}],
+                "owner": {"id": 2, "first_name": "first_name", "last_name": "last_name"},
+                "paint": "red",
                 "parts": [{"id": 5, "name": "part 1"}, {"id": 6, "name": "part 2"}],
+                "type": VehicleType.car,
             },
             models.serialize(vehicle, Vehicle.owner, Vehicle.options, Vehicle.parts),
         )
@@ -301,7 +306,7 @@ class TestModels(TestCase):
             {
                 "id": None,
                 "name": "test",
-                "employees": None,
+                "employees": 5,
                 "location": {"state": "state 1", "street": "street 1", "zip": "zip 1"},
                 "other_location": {"state": "state 2", "street": "street 2", "zip": "zip 2"},
             },

--- a/tests/models_backpop.py
+++ b/tests/models_backpop.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function, unicode_literals
 
-from django_sorcery.db import SQLAlchemy
+from django_sorcery.db import databases
 
 
-db = SQLAlchemy("minimal_backpop")
+db = databases.get("minimal_backpop")
 
 
 class Asset(db.Model):

--- a/tests/test_field_mapping.py
+++ b/tests/test_field_mapping.py
@@ -115,7 +115,8 @@ class TestFieldMapping(TestCase):
         fields = mapper.get_fields()
 
         self.assertEqual(
-            list(sorted(fields.keys())), ["created_at", "is_used", "name", "options", "owner", "paint", "parts", "type"]
+            list(sorted(fields.keys())),
+            ["created_at", "is_used", "msrp", "name", "options", "owner", "paint", "parts", "type"],
         )
         self.assertNotIn(Vehicle._owner_id.key, fields)
 

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -28,7 +28,8 @@ class TestModelForm(TestCase):
         form_class = modelform_factory(Vehicle, fields=ALL_FIELDS, session=db)
         form = form_class()
         self.assertListEqual(
-            sorted(form.fields.keys()), ["created_at", "is_used", "name", "options", "owner", "paint", "parts", "type"]
+            sorted(form.fields.keys()),
+            ["created_at", "is_used", "msrp", "name", "options", "owner", "paint", "parts", "type"],
         )
 
     def test_modelform_factory_instance_validate(self):
@@ -36,11 +37,11 @@ class TestModelForm(TestCase):
         form_class = modelform_factory(Vehicle, fields=ALL_FIELDS, session=db)
         form = form_class(instance=vehicle, data={"name": "testing"})
         self.assertFalse(form.is_valid())
-        self.assertEqual({"type": ["This field is required."]}, form.errors)
+        self.assertEqual(form.errors, {"type": ["This field is required."], "is_used": ["This field is required."]})
 
     def test_modelform_factory_instance_save(self):
         form_class = modelform_factory(Vehicle, fields=ALL_FIELDS, session=db)
-        data = {"name": "testing", "type": "car", "owner": self.owner.id}
+        data = {"name": "testing", "type": "car", "owner": self.owner.id, "is_used": True}
         form = form_class(data=data)
         self.assertTrue(form.is_valid(), form.errors)
         form.save()
@@ -60,11 +61,14 @@ class TestModelForm(TestCase):
         form = form_class(data={})
 
         self.assertTrue(form.is_bound)
-        self.assertEqual(form.errors, {"type": ["This field is required."]})
-        self.assertEqual(form.initial, {"paint": None, "created_at": None, "type": None, "name": None, "is_used": None})
+        self.assertEqual(form.errors, {"type": ["This field is required."], "is_used": ["This field is required."]})
+        self.assertEqual(
+            form.initial,
+            {"paint": None, "created_at": None, "type": None, "msrp": None, "name": None, "is_used": False},
+        )
         self.assertEqual(
             form.cleaned_data,
-            {"paint": "", "created_at": None, "options": [], "parts": [], "name": "", "is_used": None, "owner": None},
+            {"paint": "", "created_at": None, "options": [], "parts": [], "msrp": None, "name": "", "owner": None},
         )
 
         form.order_fields(sorted(form.fields.keys()))
@@ -75,14 +79,16 @@ class TestModelForm(TestCase):
                 [
                     "<p>",
                     '  <label for="id_created_at">Created at:</label>',
-                    '  <input type="text" name="created_at" id="id_created_at" />' "</p>",
+                    '  <input type="text" name="created_at" id="id_created_at" />',
+                    "</p>",
+                    '<ul class="errorlist"><li>This field is required.</li></ul>',
                     "<p>",
                     '  <label for="id_is_used">Is used:</label>',
-                    '  <select name="is_used" id="id_is_used">',
-                    '    <option value="1" selected>Unknown</option>',
-                    '    <option value="2">Yes</option>',
-                    '    <option value="3">No</option>',
-                    "  </select>",
+                    '  <input id="id_is_used" name="is_used" required="" type="checkbox"/>',
+                    "</p>",
+                    "<p>",
+                    '  <label for="id_msrp">Msrp:</label>',
+                    '  <input id="id_msrp" name="msrp" step="0.01" type="number"/>',
                     "</p>",
                     "<p>",
                     '  <label for="id_name">Name:</label>',
@@ -145,21 +151,22 @@ class TestModelForm(TestCase):
         form = form_class(instance=vehicle, data={})
 
         self.assertTrue(form.is_bound)
-        self.assertEqual(form.errors, {"type": ["This field is required."]})
+        self.assertEqual(form.errors, {"type": ["This field is required."], "is_used": ["This field is required."]})
         self.assertEqual(
             form.initial,
             {
-                "paint": None,
                 "created_at": None,
-                "type": VehicleType.car,
+                "is_used": False,
+                "msrp": None,
                 "name": None,
-                "is_used": None,
                 "owner": self.owner.id,
+                "paint": None,
+                "type": VehicleType.car,
             },
         )
         self.assertEqual(
             form.cleaned_data,
-            {"paint": "", "created_at": None, "options": [], "parts": [], "name": "", "is_used": None, "owner": None},
+            {"paint": "", "msrp": None, "created_at": None, "options": [], "parts": [], "name": "", "owner": None},
         )
 
         form.order_fields(sorted(form.fields.keys()))
@@ -170,14 +177,16 @@ class TestModelForm(TestCase):
                 [
                     "<p>",
                     '  <label for="id_created_at">Created at:</label>',
-                    '  <input type="text" name="created_at" id="id_created_at" />' "</p>",
+                    '  <input type="text" name="created_at" id="id_created_at" />',
+                    "</p>",
+                    '<ul class="errorlist"><li>This field is required.</li></ul>',
                     "<p>",
                     '  <label for="id_is_used">Is used:</label>',
-                    '  <select name="is_used" id="id_is_used">',
-                    '    <option value="1" selected>Unknown</option>',
-                    '    <option value="2">Yes</option>',
-                    '    <option value="3">No</option>',
-                    "  </select>",
+                    '  <input id="id_is_used" name="is_used" required type="checkbox" />',
+                    "</p>",
+                    "<p>",
+                    '  <label for="id_msrp">Msrp:</label>',
+                    '  <input id="id_msrp" name="msrp" step="0.01" type="number" />',
                     "</p>",
                     "<p>",
                     '  <label for="id_name">Name:</label>',

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -76,11 +76,12 @@ class Owner(db.Model):
 
 class Vehicle(db.Model):
     id = db.IntegerField(autoincrement=True, primary_key=True, doc="The primary key")
-    name = db.CharField(doc="The name of the vehicle")
+    name = db.CharField(doc="The name of the vehicle", label="Name")
     type = db.EnumField(choices=VehicleType, constraint_name="ck_vehicle_type", nullable=False)
     created_at = db.DateTimeField()
     paint = db.EnumField(choices=COLORS, constraint_name="ck_colors")
     is_used = db.BooleanField()
+    msrp = db.DecimalField(max_digits=10, decimal_places=2)
 
     owner = db.ManyToOne(Owner, backref="vehicles")
 

--- a/tests/views/test_edit.py
+++ b/tests/views/test_edit.py
@@ -68,7 +68,7 @@ class TestCreateView(TestCase):
 
         form = response.context_data["form"]
         self.assertFalse(form.is_valid())
-        self.assertEqual(form.errors, {"type": ["This field is required."]})
+        self.assertEqual(form.errors, {"type": ["This field is required."], "is_used": ["This field is required."]})
         self.assertHTMLEqual(response.content.decode(), form.as_p())
 
 


### PR DESCRIPTION
- Added nice api for `model_info` with better repr and magics so now you can do something like this:
```python
info = model_info(Person)
form_field = info.first_name.formfield()
```
- Allow overriding form class with our custom fields by passing `form_class=..` or using `info["form_class"]`