### PR TITLE
Changing force_text to force_str (Django 4.0.3)

### DIFF
--- a/django_sorcery/db/url.py
+++ b/django_sorcery/db/url.py
@@ -4,7 +4,7 @@ from importlib import import_module
 
 import sqlalchemy as sa
 from django.conf import settings
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.module_loading import import_string
 
 
@@ -27,11 +27,11 @@ def integer(x):
 
 
 def string(x):
-    return force_text(x)
+    return force_str(x)
 
 
 def string_list(x):
-    return force_text(x).split(",")
+    return force_str(x).split(",")
 
 
 def importable(x):
@@ -42,11 +42,11 @@ def importable(x):
 
 
 def importable_list(x):
-    return [importable(i) for i in force_text(x).split(",")]
+    return [importable(i) for i in force_str(x).split(",")]
 
 
 def importable_list_tuples(x):
-    return [(importable(i), j) for i, j in [k.split(":") for k in force_text(x).split(",")]]
+    return [(importable(i), j) for i, j in [k.split(":") for k in force_str(x).split(",")]]
 
 
 ENGINE_OPTIONS_NORMALIZATION = {


### PR DESCRIPTION
When running django-rest-witchcraft over Django 4.0.3 project, there exists a problem when trying to run Django server:
```
  File "[route-to-venv]/lib/python3.9/site-packages/rest_witchcraft/serializers.py", line 13, in <module>
    from django_sorcery.db import meta
  File "[route-to-venv]/lib/python3.9/site-packages/django_sorcery/db/__init__.py", line 141, in <module>
    from .sqlalchemy import SQLAlchemy  # noqa
  File "[route-to-venv]/lib/python3.9/site-packages/django_sorcery/db/sqlalchemy.py", line 11, in <module>
    from . import fields, signals
  File "[route-to-venv]/lib/python3.9/site-packages/django_sorcery/db/fields.py", line 11, in <module>
    from .url import DIALECT_MAP_TO_DJANGO
  File "[route-to-venv]/lib/python3.9/site-packages/django_sorcery/db/url.py", line 7, in <module>
    from django.utils.encoding import force_text
ImportError: cannot import name 'force_text' from 'django.utils.encoding' ([route-to-venv]/lib/python3.9/site-packages/django/utils/encoding.py)
```

I looked for a fix for this bug through Internet and I found that it's as easy as changing uses of `force_text` by `force_str` and it all seems to be working properly.